### PR TITLE
Missionsandmodsmissingonlocationswitch bugfix

### DIFF
--- a/A3ServerTool/Storage/MissionDao.cs
+++ b/A3ServerTool/Storage/MissionDao.cs
@@ -28,7 +28,7 @@ namespace A3ServerTool.Storage
             var missions = new List<Mission>();
 
             var missionFolderContent = FileHelper.GetFolder(gamePath)?
-                .FirstOrDefault(f => f.Name == MissionFolderName);
+                .FirstOrDefault(f => string.Equals(f.Name, MissionFolderName, StringComparison.OrdinalIgnoreCase));
             if (missionFolderContent == null) return missions;
 
             var files = FileHelper.GetAllFiles(missionFolderContent)

--- a/A3ServerTool/ViewModels/ProfilesViewModel.cs
+++ b/A3ServerTool/ViewModels/ProfilesViewModel.cs
@@ -96,8 +96,15 @@ namespace A3ServerTool.ViewModels
                                return;
                            }
 
+                           var oldExecutablePath = _mainViewModel?.CurrentProfile?.ExecutablePath;
                            _mainViewModel.CurrentProfile = _profileDirector.GetById(SelectedProfile.Id);
                            Messenger.Default.Send("UpdateFinalString", GeneralViewModel.Token);
+
+                           if(_mainViewModel.CurrentProfile.ExecutablePath != oldExecutablePath)
+                           {
+                               Messenger.Default.Send("UpdateMissions", MissionsViewModel.Token);
+                               Messenger.Default.Send("UpdateMods", ModificationsViewModel.Token);
+                           }
                        }, _ => SelectedProfile != null));
             }
         }
@@ -144,9 +151,14 @@ namespace A3ServerTool.ViewModels
                            var dialogResult = await _dialogCoordinator.ShowMessageAsync(this, "Confirm deletion",
                                "Are you sure that you want to delete this item?", MessageDialogStyle.AffirmativeAndNegative);
                            if (dialogResult != MessageDialogResult.Affirmative) return;
+                           if (_mainViewModel.CurrentProfile.Id == SelectedProfile.Id)
+                           {
+                               _mainViewModel.CurrentProfile = new Profile(Guid.NewGuid());
+                               Messenger.Default.Send("UpdateMissions", MissionsViewModel.Token);
+                               Messenger.Default.Send("UpdateMods", ModificationsViewModel.Token);
+                           }
 
                            _profileDirector.Delete(SelectedProfile);
-                           _mainViewModel.CurrentProfile = new Profile(Guid.NewGuid());
 
                            RefreshData();
                        }, _ => SelectedProfile != null));
@@ -193,6 +205,8 @@ namespace A3ServerTool.ViewModels
                 if (!Equals(DialogResult.Object.Id, _mainViewModel.CurrentProfile?.Id))
                 {
                     _mainViewModel.CurrentProfile = DialogResult.Object;
+                    Messenger.Default.Send("UpdateMissions", MissionsViewModel.Token);
+                    Messenger.Default.Send("UpdateMods", ModificationsViewModel.Token);
                 }
             }
 

--- a/A3ServerTool/ViewModels/ServerSubViewModels/MissionsViewModel.cs
+++ b/A3ServerTool/ViewModels/ServerSubViewModels/MissionsViewModel.cs
@@ -3,6 +3,7 @@ using A3ServerTool.Helpers;
 using A3ServerTool.Models;
 using A3ServerTool.Storage;
 using GalaSoft.MvvmLight;
+using GalaSoft.MvvmLight.Messaging;
 using Interchangeable;
 using System;
 using System.Collections.Generic;
@@ -19,6 +20,8 @@ namespace A3ServerTool.ViewModels.ServerSubViewModels
     /// <seealso cref="GalaSoft.MvvmLight.ViewModelBase" />
     public class MissionsViewModel : ViewModelBase
     {
+        public const string Token = nameof(MissionsViewModel);
+
         private readonly ServerViewModel _parentViewModel;
         private readonly IDao<Mission> _missionDao;
         private readonly GameLocationFinder _locationFinder;
@@ -181,6 +184,8 @@ namespace A3ServerTool.ViewModels.ServerSubViewModels
             _missions = new ObservableCollection<Mission>(CurrentProfile.ServerConfig.Missions);
             _missionDao = missionDao;
             _locationFinder = locationFinder;
+
+            Messenger.Default.Register<string>(this, Token, DoByRequest);
         }
 
         private Task RefreshMissions()
@@ -188,6 +193,7 @@ namespace A3ServerTool.ViewModels.ServerSubViewModels
             var gamePath = _locationFinder.GetGameInstallationPath(CurrentProfile);
             if (string.IsNullOrWhiteSpace(gamePath))
             {
+                Missions.Clear();
                 return Task.FromResult<object>(null);
             }
 
@@ -219,6 +225,15 @@ namespace A3ServerTool.ViewModels.ServerSubViewModels
                     Missions = new ObservableCollection<Mission>(CurrentProfile.ServerConfig.Missions);
                 }
             });
+        }
+
+        /// <summary>
+        /// Refreshes mission list by requests from other view models.
+        /// </summary>
+        /// <param name="request">message to do something in this viewmodel.</param>
+        private void DoByRequest(string request)
+        {
+            RefreshMissions();
         }
     }
 }

--- a/A3ServerTool/ViewModels/ServerSubViewModels/ModificationsViewModel.cs
+++ b/A3ServerTool/ViewModels/ServerSubViewModels/ModificationsViewModel.cs
@@ -8,6 +8,7 @@ using A3ServerTool.Helpers;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using A3ServerTool.Storage;
+using GalaSoft.MvvmLight.Messaging;
 
 namespace A3ServerTool.ViewModels.ServerSubViewModels
 {
@@ -17,6 +18,8 @@ namespace A3ServerTool.ViewModels.ServerSubViewModels
     /// <seealso cref="GalaSoft.MvvmLight.ViewModelBase" />
     public class ModificationsViewModel : ViewModelBase
     {
+        public const string Token = nameof(ModificationsViewModel);
+
         private readonly ServerViewModel _parentViewModel;
         private readonly GameLocationFinder _locationFinder;
         private readonly IDao<Modification> _modDao;
@@ -163,6 +166,8 @@ namespace A3ServerTool.ViewModels.ServerSubViewModels
             _mods = new ObservableCollection<Modification>(CurrentProfile.ArgumentSettings.Modifications);
             _modDao = modDao;
             _locationFinder = locationFinder;
+
+            Messenger.Default.Register<string>(this, Token, DoByRequest);
         }
 
         private Task RefreshModifications()
@@ -170,6 +175,7 @@ namespace A3ServerTool.ViewModels.ServerSubViewModels
             var gamePath = _locationFinder.GetGameInstallationPath(CurrentProfile);
             if (string.IsNullOrWhiteSpace(gamePath))
             {
+                Modifications.Clear();
                 return Task.FromResult<object>(null);
             }
 
@@ -214,6 +220,15 @@ namespace A3ServerTool.ViewModels.ServerSubViewModels
         private void OnModChanged(object sender, EventArgs e)
         {
             RaisePropertyChanged("ModificationsCounter");
+        }
+
+        /// <summary>
+        /// Refreshes modlist by requests from other view models.
+        /// </summary>
+        /// <param name="request">message to do something in this viewmodel.</param>
+        private void DoByRequest(string request)
+        {
+            RefreshModifications();
         }
     }
 }


### PR DESCRIPTION
Attempt to some bugs with current mission/modification system implementations - if mission folder name differss from "MpMissions" then there will be no missions in lists (case sensitive match check)